### PR TITLE
Replace Xmonad with Hyprland

### DIFF
--- a/machines/omega/configuration.nix
+++ b/machines/omega/configuration.nix
@@ -89,8 +89,9 @@
   services.xserver.displayManager.lightdm.enable = true;
   services.xserver.displayManager.lightdm.greeters.mini.enable = true;
   services.xserver.displayManager.lightdm.greeters.mini.user = "placek";
-  services.xserver.enable = true;
-  services.xserver.windowManager.xmonad.enable = true;
+  services.xserver.enable = false;
+  services.xserver.windowManager.xmonad.enable = lib.mkForce false;
+  programs.hyprland.enable = true;
   services.xserver.xkb.layout = "pl";
   services.xserver.displayManager.lightdm.greeters.mini.extraConfig = ''
   [greeter]

--- a/modules/gui/default.nix
+++ b/modules/gui/default.nix
@@ -54,19 +54,19 @@
     ./fonts.nix
 
     ./autorandr
-    ./dunst.nix
+    ./mako.nix
     ./feh.nix
-    ./xmobar.nix
     ./mpv.nix
     ./zathura.nix
 
-    ./xmonad
+    ./hyprland
     ./games.nix
   ];
 
   config = {
     home.packages = with pkgs; [
-      (pkgs.writeShellScriptBin "wallpaper" "feh --bg-fill '${config.gui.wallpaper}'")
+      swaybg
+      (pkgs.writeShellScriptBin "wallpaper" "swaybg --mode fill --image '${config.gui.wallpaper}'")
 
       libnotify
       xf86_input_wacom

--- a/modules/gui/hyprland/default.nix
+++ b/modules/gui/hyprland/default.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+let
+  sshot = import ./sshot.nix { inherit config pkgs; };
+  wallpaperScript = "wallpaper"; # script from gui/default.nix
+in {
+  config = {
+    wayland.windowManager.hyprland = {
+      enable = true;
+      extraConfig = ''
+        $mod = SUPER
+
+        exec-once = ${wallpaperScript} &
+
+        bind = $mod, RETURN, exec, ${config.terminalExec}
+        bind = $mod, SPACE, exec, ${config.menuExec}
+        bind = $mod SHIFT, Q, exit
+        bind = $mod, Q, killactive
+        bind = , Print, exec, ${sshot}/bin/sshot selection
+        bind = SHIFT, Print, exec, ${sshot}/bin/sshot window
+        bind = $mod, ESCAPE, exec, ${pkgs.mako}/bin/makoctl dismiss
+      '';
+    };
+
+    programs.waybar.enable = true;
+  };
+}

--- a/modules/gui/hyprland/sshot.nix
+++ b/modules/gui/hyprland/sshot.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+pkgs.writeShellScriptBin "sshot" ''
+  file="${config.downloadsDirectory}/sshot.png"
+  case "$1" in
+    w*)
+      region=$(${pkgs.slurp}/bin/slurp -u)
+      ${pkgs.grim}/bin/grim -g "$region" "$file"
+      ;;
+    s*)
+      region=$(${pkgs.slurp}/bin/slurp)
+      ${pkgs.grim}/bin/grim -g "$region" "$file"
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+  ${pkgs.wl-clipboard}/bin/wl-copy < "$file"
+''

--- a/modules/gui/mako.nix
+++ b/modules/gui/mako.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+{
+  services.mako = {
+    enable = true;
+    font = "${config.gui.font.name} ${builtins.toString config.gui.font.size}";
+    backgroundColor = config.gui.theme.base00;
+    borderColor = config.gui.theme.base03;
+    textColor = config.gui.theme.base0F;
+    borderSize = config.gui.border.size;
+  };
+}


### PR DESCRIPTION
## Summary
- use Hyprland instead of xmonad
- switch notifications to mako
- use swaybg for wallpaper
- add a simple Wayland screenshot script
- enable Hyprland at the system level

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852a1a9c4a48320b01337ea555601cf