### PR TITLE
Switch XMonad setup to Hyprland

### DIFF
--- a/machines/omega/configuration.nix
+++ b/machines/omega/configuration.nix
@@ -86,33 +86,12 @@
   services.libinput.touchpad.tapping = false;
   services.logind.extraConfig = "HandlePowerKey=ignore";
   services.logind.lidSwitch = "ignore";
-  services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.displayManager.lightdm.greeters.mini.enable = true;
-  services.xserver.displayManager.lightdm.greeters.mini.user = "placek";
-  services.xserver.enable = true;
-  services.xserver.windowManager.xmonad.enable = true;
-  services.xserver.xkb.layout = "pl";
-  services.xserver.displayManager.lightdm.greeters.mini.extraConfig = ''
-  [greeter]
-  show-password-label = false
-  invalid-password-text = nope!
-  show-input-cursor = false
-  password-alignment = left
-  password-input-width = 24
+  services.greetd.enable = true;
+  services.greetd.settings.default_session.command = "${pkgs.hyprland}/bin/Hyprland";
 
-  [greeter-theme]
-  font = "Iosevka"
-  font-weight = normal
-  error-color = "#d5c4a1"
-  password-color = "#d5c4a1"
-  background-color = "#32302f"
-  background-image = ""
-  window-color = "#32302f"
-  border-color = "#fe8019"
-border-width = 4px
-  password-background-color = "#32302f"
-  password-border-width = 0px
-  '';
+  services.xserver.enable = false;
+  programs.hyprland.enable = true;
+  services.xserver.xkb.layout = "pl";
 
   services.pipewire = {
     enable = true;

--- a/modules/gui/default.nix
+++ b/modules/gui/default.nix
@@ -56,11 +56,11 @@
     ./autorandr
     ./dunst.nix
     ./feh.nix
-    ./xmobar.nix
+    ./eww.nix
     ./mpv.nix
     ./zathura.nix
 
-    ./xmonad
+    ./hyprland.nix
     ./games.nix
   ];
 

--- a/modules/gui/eww.nix
+++ b/modules/gui/eww.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+{
+  config = {
+    home.packages = [ pkgs.eww ];
+    xdg.configFile."eww/bar.yuck".text = ''
+      (defwidget bar []
+        (box :class "bar" (label :text "eww")))
+    '';
+    systemd.user.services.eww = {
+      Unit.Description = "eww bar";
+      Service = {
+        ExecStart = "${pkgs.eww}/bin/eww daemon --config ${config.xdg.configHome}/eww";
+        Restart = "on-failure";
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/modules/gui/hyprland.nix
+++ b/modules/gui/hyprland.nix
@@ -1,0 +1,65 @@
+{ config, lib, pkgs, ... }:
+let
+  sshot = import ./xmonad/sshot.nix { inherit config pkgs; };
+  runPrompt = "${pkgs.writeShellScriptBin "run-prompt" "${config.gui.menuExec}"}";
+  clipboardPrompt = "${pkgs.writeShellScriptBin "clipboard-prompt" "${config.home.homeDirectory}/.local/bin/clipboard-prompt"}";
+  passPrompt = "${pkgs.writeShellScriptBin "pass-prompt" "${config.home.homeDirectory}/.local/bin/pass-prompt"}";
+  udisksPrompt = "${pkgs.writeShellScriptBin "udisks-prompt" "${config.home.homeDirectory}/.local/bin/udisks-prompt"}";
+  terminal = config.terminalExec;
+  hyprlandCmd = "${pkgs.hyprland}/bin/Hyprland";
+  startEww = "${pkgs.eww}/bin/eww daemon --config ${config.xdg.configHome}/eww & ${pkgs.eww}/bin/eww open bar";
+  prompt = "${config.gui.menuExec}";
+  clipboard = "clipboard-prompt";
+  pass = "pass-prompt";
+  udisks = "udisks-prompt";
+  screenshotSelection = "${sshot}/bin/sshot selection";
+  screenshotWindow = "${sshot}/bin/sshot window";
+in
+{
+  config = {
+    home.packages = [ pkgs.hyprland pkgs.eww sshot ];
+    wayland.windowManager.hyprland.enable = true;
+    wayland.windowManager.hyprland.extraConfig = ''
+      $mod = SUPER
+      exec-once = wallpaper & ${startEww}
+
+      bind = $mod, RETURN, exec, ${terminal}
+      bind = $mod, BACKSPACE, exec, ${prompt}
+      bind = $mod, C, exec, ${clipboard}
+      bind = $mod, P, exec, ${pass}
+      bind = $mod, M, exec, ${udisks}
+
+      bind = $mod, H, workspace, -1
+      bind = $mod, L, workspace, +1
+      bind = $mod SHIFT, H, movetoworkspace, -1
+      bind = $mod SHIFT, L, movetoworkspace, +1
+      bind = $mod CTRL, H, focusmonitor, l
+      bind = $mod CTRL, L, focusmonitor, r
+      bind = $mod, K, movefocus, u
+      bind = $mod, J, movefocus, d
+      bind = $mod SHIFT, K, movewindow, u
+      bind = $mod SHIFT, J, movewindow, d
+      bind = $mod CTRL, K, resizeactive, 0 -20
+      bind = $mod CTRL, J, resizeactive, 0 20
+      bind = $mod, SPACE, layoutmsg, cyclenext
+      bind = $mod CTRL, SPACE, togglefloating
+      bind = $mod SHIFT, SPACE, centerwindow
+      bind = $mod, Q, killactive
+      bind = $mod SHIFT, Q, exit
+
+      bind = , XF86AudioPrev, exec, playerctl previous
+      bind = , XF86AudioPlay, exec, playerctl play-pause
+      bind = , XF86AudioNext, exec, playerctl next
+      bind = , XF86AudioMute, exec, amixer set Master toggle
+      bind = , XF86Calculator, exec, amixer set Capture toggle
+      bind = , XF86AudioLowerVolume, exec, amixer set Master 5%- unmute
+      bind = , XF86AudioRaiseVolume, exec, amixer set Master 5%+ unmute
+      bind = , XF86MonBrightnessUp, exec, light -A 5
+      bind = , XF86MonBrightnessDown, exec, light -U 5
+      bind = , XF86Sleep, exec, slock
+      bind = , XF86PowerOff, exec, slock
+      bind = SHIFT, Print, exec, ${screenshotWindow}
+      bind = , Print, exec, ${screenshotSelection}
+    '';
+  };
+}


### PR DESCRIPTION
## Summary
- replace xmobar with eww
- add hyprland module replicating XMonad keybindings
- update GUI imports for Hyprland/Eww
- swap LightDM + XMonad for greetd + Hyprland

## Testing
- `nix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2da0e85c832095fe8390ef6150f2